### PR TITLE
change code scanning default languages to none for cda

### DIFF
--- a/otterdog/eclipse-opensovd.jsonnet
+++ b/otterdog/eclipse-opensovd.jsonnet
@@ -127,6 +127,9 @@ orgs.newOrg('automotive.opensovd', 'eclipse-opensovd') {
       has_wiki: true,
       homepage: "",
       code_scanning_default_setup_enabled: true,
+      code_scanning_default_languages+: [
+        "actions",
+      ],
       description: "🚗 Classic Diagnostic Adapter 🏥",
       variables: [
         orgs.newRepoVariable('SONAR_PROJECT_KEY') {


### PR DESCRIPTION
change code scanning default languages to none to avoid issues with java-kotlin
scanning of integration test setup code.

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

