### PR TITLE
chore: enable github pages for dlt-tracing-lib

### DIFF
--- a/otterdog/eclipse-opensovd.jsonnet
+++ b/otterdog/eclipse-opensovd.jsonnet
@@ -264,6 +264,7 @@ orgs.newOrg('automotive.opensovd', 'eclipse-opensovd') {
       has_issues: true,
       has_projects: true,
       has_wiki: true,
+      gh_pages_build_type: "workflow",
       code_scanning_default_setup_enabled: true,
       description: "Tracing appender and wrapper for libdlt",
       rulesets+: [


### PR DESCRIPTION
Enable github pages, to publish the documentation of the crates in the repo to github pages instead of storing them in the repo.

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
The current PR in review https://github.com/eclipse-opensovd/dlt-tracing-lib/pull/1 contains the generated documentation, to make it available in a browser without having to clone the repo. 
Storing the docs in the repo is a workaround as github pages are not enabled. 
This PR enables github pages for the repo, so we are able to host the generated documentation.
## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)