### PR TITLE
chore: add ci cd repo

### DIFF
--- a/otterdog/eclipse-opensovd.jsonnet
+++ b/otterdog/eclipse-opensovd.jsonnet
@@ -276,5 +276,28 @@ orgs.newOrg('automotive.opensovd', 'eclipse-opensovd') {
         },
       ],
     },
+    orgs.newRepo('cicd-workflows') {
+      allow_merge_commit: false,
+      allow_rebase_merge: true,
+      allow_squash_merge: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: true,
+      dependabot_alerts_enabled: true,
+      dependabot_security_updates_enabled: true,
+      has_discussions: true,
+      has_issues: true,
+      has_projects: true,
+      has_wiki: true,
+      code_scanning_default_setup_enabled: true,
+      description: "Reusable GitHub Actions workflows for CI/CD automation",
+      rulesets+: [
+        orgs.newRepoRuleset('main') {
+          include_refs+: [
+            "refs/heads/main"
+          ],
+          required_pull_request+: default_review_rule,
+        },
+      ],
+    },
   ],
 }


### PR DESCRIPTION
This commit is adding a new repository,
which will contain re-usable ci/cd assets
that can be shared between different repos.

For example:
* license check
* formatting of common files
* end of line check

Solves https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/99

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
