### PR TITLE
feat: add mbedtls-rs repo

### DIFF
--- a/otterdog/eclipse-opensovd.jsonnet
+++ b/otterdog/eclipse-opensovd.jsonnet
@@ -418,5 +418,41 @@ orgs.newOrg('automotive.opensovd', 'eclipse-opensovd') {
         "uds"
       ],
     },
+    orgs.newRepo('mbedtls-rs') {
+      allow_merge_commit: false,
+      allow_rebase_merge: true,
+      allow_squash_merge: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: true,
+      dependabot_alerts_enabled: true,
+      dependabot_security_updates_enabled: true,
+      has_discussions: true,
+      has_issues: true,
+      has_projects: false,
+      has_wiki: false,
+      code_scanning_default_setup_enabled: true,
+      code_scanning_default_languages+: [
+        "actions",
+        "c-cpp",
+        "rust",
+      ],
+      description: "Patched Mbed TLS and Rust bindings for OpenSOVD",
+      rulesets: [
+        orgs.newRepoRuleset('main') {
+          include_refs+: [
+            "refs/heads/main"
+          ],
+          required_pull_request+: default_review_rule,
+        },
+      ],
+      topics+: [
+        "automotive",
+        "bazel",
+        "mbedtls",
+        "opensovd",
+        "rust",
+        "tls",
+      ],
+    },
   ],
 }


### PR DESCRIPTION
CDA needs some TLS features that are not available in rustls (NULLCIPHER) or openssl (RFC 8449 - Record Size Limit Extension), but are provided by mbedtls. This repo will contain the mbedtls source in a specific version,  mbedtls rust bindings (and async stream) as well as required patches for mbedtls as needed for CDA.

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)